### PR TITLE
Fix a bug that can't read hearthstone log file due to the log's folder changed

### DIFF
--- a/HDT-Reconnector/Properties/AssemblyInfo.cs
+++ b/HDT-Reconnector/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.4.0")]
-[assembly: AssemblyFileVersion("1.4.4.0")]
+[assembly: AssemblyVersion("1.4.5.0")]
+[assembly: AssemblyFileVersion("1.4.5.0")]

--- a/HDT-Reconnector/ReconnectorPlugin.cs
+++ b/HDT-Reconnector/ReconnectorPlugin.cs
@@ -25,7 +25,7 @@ namespace HDT_Reconnector
 
         public string Author => "Hypervisor";
 
-        public Version Version => Version.Parse("1.4.4");
+        public Version Version => Version.Parse("1.4.5");
 
         public MenuItem MenuItem { get; private set; }
 


### PR DESCRIPTION
The Hearthstone logs are stored in Logs/Hearthstone_<date> instead of Logs/ since last update.

This PR fixes the log search path and log filename.

Fixes #19 